### PR TITLE
Fix a missing _data attribute

### DIFF
--- a/pyusbtin/canmessage.py
+++ b/pyusbtin/canmessage.py
@@ -105,6 +105,7 @@ class CANMessage(object):
         self.name = name
         self.rtr = rtr
         self.extended = True if mid > 0x7ff else False
+        self._data = 0
 
         if rtr:
             if self.mid in self.dbc_info and dlc != self.dbc_info[self.mid]['dlc']:


### PR DESCRIPTION
When running the examples to send frames I received an error about a missing '_data' attribute and found by initialising in the constructor clears the issue.